### PR TITLE
[WIP] Refactor to distill code diff relative to rust-crypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,9 +767,11 @@ name = "p256"
 version = "0.13.2"
 dependencies = [
  "blobby",
+ "cfg-if",
  "criterion",
  "ecdsa",
  "elliptic-curve",
+ "hex",
  "hex-literal",
  "primeorder",
  "proptest",

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -1,6 +1,6 @@
 //! Field arithmetic modulo p = 2^256 - 2^32 - 2^9 - 2^8 - 2^7 - 2^6 - 2^4 - 1
 
-#![allow(clippy::assign_op_pattern, clippy::op_ref)]
+#![allow(clippy::assign_op_pattern, clippy::op_ref, unused_qualifications)]
 
 use cfg_if::cfg_if;
 

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -1,5 +1,7 @@
 //! Scalar field arithmetic.
 
+#![allow(unused_qualifications)]
+
 #[cfg_attr(not(target_pointer_width = "64"), path = "scalar/wide32.rs")]
 #[cfg_attr(target_pointer_width = "64", path = "scalar/wide64.rs")]
 mod wide;

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -21,7 +21,6 @@ cfg-if = "1.0"
 elliptic-curve = { version = "0.13.8", default-features = false, features = ["hazmat", "sec1"] }
 
 # optional dependencies
-once_cell = { version = "1.19", optional = true, default-features = false }
 ecdsa-core = { version = "0.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 hex-literal = { version = "0.4", optional = true }
 primeorder = { version = "0.13", optional = true, path = "../primeorder" }
@@ -36,7 +35,7 @@ primeorder = { version = "0.13.5", features = ["dev"], path = "../primeorder" }
 rand_core = { version = "0.6", features = ["getrandom"] }
 
 [target.'cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))'.dev-dependencies]
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.5" }
 proptest = "1.4"
 
 [target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dev-dependencies]
@@ -46,7 +45,7 @@ hex = "0.4"
 [features]
 default = ["arithmetic", "ecdsa", "pem", "std"]
 alloc = ["ecdsa-core?/alloc", "elliptic-curve/alloc", "primeorder?/alloc"]
-std = ["alloc", "ecdsa-core?/std", "elliptic-curve/std", "once_cell?/std"]
+std = ["alloc", "ecdsa-core?/std", "elliptic-curve/std"]
 
 arithmetic = ["dep:primeorder", "elliptic-curve/arithmetic"]
 bits = ["arithmetic", "elliptic-curve/bits"]

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -10,6 +10,7 @@ pub(crate) mod field;
 mod hash2curve;
 pub(crate) mod projective;
 pub(crate) mod scalar;
+pub(crate) mod util;
 
 use self::{field::FieldElement, scalar::Scalar};
 use crate::NistP256;

--- a/p256/src/arithmetic/affine.rs
+++ b/p256/src/arithmetic/affine.rs
@@ -35,6 +35,7 @@ pub struct AffinePoint {
     pub(crate) infinity: u8,
 }
 
+// NOTE: Removes the PrimeCurveParams generic. TODO impl PrimeCurveParams
 impl AffinePoint {
     /// Additive identity of the group a.k.a. the point at infinity.
     pub const IDENTITY: Self = Self {

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -1,6 +1,6 @@
 //! Field arithmetic modulo p = 2^{224}(2^{32} − 1) + 2^{192} + 2^{96} − 1
 
-#![allow(clippy::assign_op_pattern, clippy::op_ref)]
+#![allow(clippy::assign_op_pattern, clippy::op_ref, unused_qualifications)]
 
 #[cfg_attr(
     all(target_os = "zkvm", target_arch = "riscv32"),
@@ -67,7 +67,7 @@ impl FieldElement {
     }
 
     /// Convert a `u64` into a [`FieldElement`].
-    pub const fn from_u64(w: u64) -> Self {
+    pub fn from_u64(w: u64) -> Self {
         Self::from_uint_unchecked(U256::from_u64(w))
     }
 
@@ -76,7 +76,7 @@ impl FieldElement {
     /// Does *not* perform a check that the field element does not overflow the order.
     ///
     /// This method is primarily intended for defining internal constants.
-    pub(crate) const fn from_hex(hex: &str) -> Self {
+    pub(crate) fn from_hex(hex: &str) -> Self {
         Self::from_uint_unchecked(U256::from_be_hex(hex))
     }
 
@@ -85,7 +85,7 @@ impl FieldElement {
     /// Does *not* perform a check that the field element does not overflow the order.
     ///
     /// Used incorrectly this can lead to invalid results!
-    pub(crate) const fn from_uint_unchecked(w: U256) -> Self {
+    pub(crate) fn from_uint_unchecked(w: U256) -> Self {
         field_impl::from_uint_unchecked(w)
     }
 
@@ -95,7 +95,7 @@ impl FieldElement {
     ///
     /// If zero, return `Choice(1)`.  Otherwise, return `Choice(0)`.
     pub fn is_zero(&self) -> Choice {
-        field_impl::is_zero(&self)
+        field_impl::is_zero(self)
     }
 
     /// Determine if this `FieldElement` is odd in the SEC1 sense: `self mod 2 == 1`.
@@ -110,24 +110,24 @@ impl FieldElement {
 
     /// Returns self + rhs mod p
     pub const fn add(&self, rhs: &Self) -> Self {
-        field_impl::add(&self, &rhs)
+        field_impl::add(self, rhs)
     }
 
     /// Multiplies by a single-limb integer.
     ///
     /// Multiplies the magnitude by the same value.
     pub fn mul_single(&self, rhs: u32) -> Self {
-        field_impl::mul_single(&self, rhs)
+        field_impl::mul_single(self, rhs)
     }
 
     /// Returns 2*self.
     pub fn double(&self) -> Self {
-        field_impl::double(&self)
+        field_impl::double(self)
     }
 
     /// Returns self - rhs mod p
     pub fn sub(&self, rhs: &Self) -> Self {
-        field_impl::sub(&self, &rhs)
+        field_impl::sub(self, rhs)
     }
 
     /// Negate element.
@@ -137,7 +137,7 @@ impl FieldElement {
 
     /// Returns self * rhs mod p
     pub fn multiply(&self, rhs: &Self) -> Self {
-        field_impl::mul(self.0, rhs.0)
+        field_impl::multiply(self, rhs)
     }
 
     /// Returns self * self mod p

--- a/p256/src/arithmetic/field/field64.rs
+++ b/p256/src/arithmetic/field/field64.rs
@@ -1,7 +1,20 @@
 //! 64-bit secp256r1 field element algorithms.
 
-use super::{MODULUS, MODULUS_HEX};
+use super::{FieldElement, MODULUS, MODULUS_HEX};
 use elliptic_curve::bigint::{Limb, U256};
+
+/// R = 2^256 mod p
+const R: FieldElement = FieldElement(U256::from_be_hex(
+    "00000000fffffffeffffffffffffffffffffffff000000000000000000000001",
+));
+
+/// R^2 = 2^512 mod p
+const R2: FieldElement = FieldElement(U256::from_be_hex(
+    "00000004fffffffdfffffffffffffffefffffffbffffffff0000000000000003",
+));
+
+/// Multiplicative identity.
+pub(super) const ONE: FieldElement = R;
 
 pub(super) const fn add(a: U256, b: U256) -> U256 {
     let a = a.as_limbs();
@@ -64,10 +77,32 @@ fn mul_inner(a: U256, b: Limb) -> U256 {
 }
 
 /// Returns self * rhs mod p
-pub(super) fn mul(a: U256, b: U256) -> U256 {
-    let (lo, hi) = a.mul_wide(&b);
-    let (rem, _) = U256::const_rem_wide((lo, hi), &U256::from_be_hex(MODULUS_HEX));
-    rem
+pub(super) fn mul(a: &FieldElement, b: &FieldElement) -> FieldElement {
+    // Schoolbook multiplication.
+    let a = u256_to_u64x4(self.0);
+    let b = u256_to_u64x4(rhs.0);
+
+    let (w0, carry) = mac(0, a[0], b[0], 0);
+    let (w1, carry) = mac(0, a[0], b[1], carry);
+    let (w2, carry) = mac(0, a[0], b[2], carry);
+    let (w3, w4) = mac(0, a[0], b[3], carry);
+
+    let (w1, carry) = mac(w1, a[1], b[0], 0);
+    let (w2, carry) = mac(w2, a[1], b[1], carry);
+    let (w3, carry) = mac(w3, a[1], b[2], carry);
+    let (w4, w5) = mac(w4, a[1], b[3], carry);
+
+    let (w2, carry) = mac(w2, a[2], b[0], 0);
+    let (w3, carry) = mac(w3, a[2], b[1], carry);
+    let (w4, carry) = mac(w4, a[2], b[2], carry);
+    let (w5, w6) = mac(w5, a[2], b[3], carry);
+
+    let (w3, carry) = mac(w3, a[3], b[0], 0);
+    let (w4, carry) = mac(w4, a[3], b[1], carry);
+    let (w5, carry) = mac(w5, a[3], b[2], carry);
+    let (w6, w7) = mac(w6, a[3], b[3], carry);
+
+    FieldElement::montgomery_reduce(w0, w1, w2, w3, w4, w5, w6, w7)
 }
 
 pub(super) const fn sub(a: U256, b: U256) -> U256 {
@@ -75,31 +110,155 @@ pub(super) const fn sub(a: U256, b: U256) -> U256 {
     let b = b.as_limbs();
 
     let (result, _) = sub_inner(
-        [a[0], a[1], a[2], a[3], Limb::ZERO],
-        [b[0], b[1], b[2], b[3], Limb::ZERO],
+        a[0],
+        a[1],
+        a[2],
+        a[3],
+        Limb::ZERO,
+        b[0],
+        b[1],
+        b[2],
+        b[3],
+        Limb::ZERO,
     );
     U256::new([result[0], result[1], result[2], result[3]])
 }
 
+fn from_bytes_wide(bytes: [u8; 64]) -> Self {
+    #[allow(clippy::unwrap_used)]
+    FieldElement::montgomery_reduce(
+        u64::from_be_bytes(bytes[0..8].try_into().unwrap()),
+        u64::from_be_bytes(bytes[8..16].try_into().unwrap()),
+        u64::from_be_bytes(bytes[16..24].try_into().unwrap()),
+        u64::from_be_bytes(bytes[24..32].try_into().unwrap()),
+        u64::from_be_bytes(bytes[32..40].try_into().unwrap()),
+        u64::from_be_bytes(bytes[40..48].try_into().unwrap()),
+        u64::from_be_bytes(bytes[48..56].try_into().unwrap()),
+        u64::from_be_bytes(bytes[56..64].try_into().unwrap()),
+    )
+}
+
 #[inline]
 #[allow(clippy::too_many_arguments)]
-const fn sub_inner(l: [Limb; 5], r: [Limb; 5]) -> ([Limb; 4], Limb) {
-    let (w0, borrow) = l[0].sbb(r[0], Limb::ZERO);
-    let (w1, borrow) = l[1].sbb(r[1], borrow);
-    let (w2, borrow) = l[2].sbb(r[2], borrow);
-    let (w3, borrow) = l[3].sbb(r[3], borrow);
-    let (_, borrow) = l[4].sbb(r[4], borrow);
+const fn sub_inner(
+    l0: u64,
+    l1: u64,
+    l2: u64,
+    l3: u64,
+    l4: u64,
+    r0: u64,
+    r1: u64,
+    r2: u64,
+    r3: u64,
+    r4: u64,
+) -> (Self, u64) {
+    let (w0, borrow) = sbb(l0, r0, 0);
+    let (w1, borrow) = sbb(l1, r1, borrow);
+    let (w2, borrow) = sbb(l2, r2, borrow);
+    let (w3, borrow) = sbb(l3, r3, borrow);
+    let (_, borrow) = sbb(l4, r4, borrow);
 
     // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
     // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the
     // modulus.
+    let modulus = u256_to_u64x4(MODULUS.0);
+    let (w0, carry) = adc(w0, modulus[0] & borrow, 0);
+    let (w1, carry) = adc(w1, modulus[1] & borrow, carry);
+    let (w2, carry) = adc(w2, modulus[2] & borrow, carry);
+    let (w3, _) = adc(w3, modulus[3] & borrow, carry);
 
-    let modulus = MODULUS.0.as_limbs();
+    (Self(u64x4_to_u256([w0, w1, w2, w3])), borrow)
+}
 
-    let (w0, carry) = w0.adc(modulus[0].bitand(borrow), Limb::ZERO);
-    let (w1, carry) = w1.adc(modulus[1].bitand(borrow), carry);
-    let (w2, carry) = w2.adc(modulus[2].bitand(borrow), carry);
-    let (w3, _) = w3.adc(modulus[3].bitand(borrow), carry);
+/// Montgomery Reduction
+///
+/// The general algorithm is:
+/// ```text
+/// A <- input (2n b-limbs)
+/// for i in 0..n {
+///     k <- A[i] p' mod b
+///     A <- A + k p b^i
+/// }
+/// A <- A / b^n
+/// if A >= p {
+///     A <- A - p
+/// }
+/// ```
+///
+/// For secp256r1, we have the following simplifications:
+///
+/// - `p'` is 1, so our multiplicand is simply the first limb of the intermediate A.
+///
+/// - The first limb of p is 2^64 - 1; multiplications by this limb can be simplified
+///   to a shift and subtraction:
+///   ```text
+///       a_i * (2^64 - 1) = a_i * 2^64 - a_i = (a_i << 64) - a_i
+///   ```
+///   However, because `p' = 1`, the first limb of p is multiplied by limb i of the
+///   intermediate A and then immediately added to that same limb, so we simply
+///   initialize the carry to limb i of the intermediate.
+///
+/// - The third limb of p is zero, so we can ignore any multiplications by it and just
+///   add the carry.
+///
+/// References:
+/// - Handbook of Applied Cryptography, Chapter 14
+///   Algorithm 14.32
+///   http://cacr.uwaterloo.ca/hac/about/chap14.pdf
+///
+/// - Efficient and Secure Elliptic Curve Cryptography Implementation of Curve P-256
+///   Algorithm 7) Montgomery Word-by-Word Reduction
+///   https://csrc.nist.gov/csrc/media/events/workshop-on-elliptic-curve-cryptography-standards/documents/papers/session6-adalier-mehmet.pdf
+#[inline]
+#[allow(clippy::too_many_arguments)]
+const fn montgomery_reduce(
+    r0: u64,
+    r1: u64,
+    r2: u64,
+    r3: u64,
+    r4: u64,
+    r5: u64,
+    r6: u64,
+    r7: u64,
+) -> Self {
+    let modulus = u256_to_u64x4(MODULUS.0);
 
-    ([w0, w1, w2, w3], borrow)
+    let (r1, carry) = mac(r1, r0, modulus[1], r0);
+    let (r2, carry) = adc(r2, 0, carry);
+    let (r3, carry) = mac(r3, r0, modulus[3], carry);
+    let (r4, carry2) = adc(r4, 0, carry);
+
+    let (r2, carry) = mac(r2, r1, modulus[1], r1);
+    let (r3, carry) = adc(r3, 0, carry);
+    let (r4, carry) = mac(r4, r1, modulus[3], carry);
+    let (r5, carry2) = adc(r5, carry2, carry);
+
+    let (r3, carry) = mac(r3, r2, modulus[1], r2);
+    let (r4, carry) = adc(r4, 0, carry);
+    let (r5, carry) = mac(r5, r2, modulus[3], carry);
+    let (r6, carry2) = adc(r6, carry2, carry);
+
+    let (r4, carry) = mac(r4, r3, modulus[1], r3);
+    let (r5, carry) = adc(r5, 0, carry);
+    let (r6, carry) = mac(r6, r3, modulus[3], carry);
+    let (r7, r8) = adc(r7, carry2, carry);
+
+    // Result may be within MODULUS of the correct value
+    let (result, _) = Self::sub_inner(
+        r4, r5, r6, r7, r8, modulus[0], modulus[1], modulus[2], modulus[3], 0,
+    );
+    result
+}
+
+/// Translate a field element out of the Montgomery domain.
+#[inline]
+pub(crate) const fn to_canonical(self) -> Self {
+    let w = u256_to_u64x4(self.0);
+    FieldElement::montgomery_reduce(w[0], w[1], w[2], w[3], 0, 0, 0, 0)
+}
+
+/// Translate a field element into the Montgomery domain.
+#[inline]
+pub(crate) const fn to_montgomery(self) -> Self {
+    Self::multiply(&self, &R2)
 }

--- a/p256/src/arithmetic/util.rs
+++ b/p256/src/arithmetic/util.rs
@@ -1,0 +1,72 @@
+//! Helper functions.
+// TODO(tarcieri): replace these with `crypto-bigint`
+
+use elliptic_curve::bigint::U256;
+
+/// Computes `a + b + carry`, returning the result along with the new carry. 64-bit version.
+#[inline(always)]
+pub(crate) const fn adc(a: u64, b: u64, carry: u64) -> (u64, u64) {
+    let ret = (a as u128) + (b as u128) + (carry as u128);
+    (ret as u64, (ret >> 64) as u64)
+}
+
+/// Computes `a - (b + borrow)`, returning the result along with the new borrow. 64-bit version.
+#[inline(always)]
+pub(crate) const fn sbb(a: u64, b: u64, borrow: u64) -> (u64, u64) {
+    let ret = (a as u128).wrapping_sub((b as u128) + ((borrow >> 63) as u128));
+    (ret as u64, (ret >> 64) as u64)
+}
+
+/// Computes `a + (b * c) + carry`, returning the result along with the new carry.
+#[inline(always)]
+pub(crate) const fn mac(a: u64, b: u64, c: u64, carry: u64) -> (u64, u64) {
+    let ret = (a as u128) + ((b as u128) * (c as u128)) + (carry as u128);
+    (ret as u64, (ret >> 64) as u64)
+}
+
+/// Array containing 4 x 64-bit unsigned integers.
+// TODO(tarcieri): replace this entirely with `U256`
+pub(crate) type U64x4 = [u64; 4];
+
+/// Convert to a [`U64x4`] array.
+// TODO(tarcieri): implement all algorithms in terms of `U256`?
+#[cfg(target_pointer_width = "32")]
+pub(crate) const fn u256_to_u64x4(u256: U256) -> U64x4 {
+    let limbs = u256.to_words();
+
+    [
+        (limbs[0] as u64) | ((limbs[1] as u64) << 32),
+        (limbs[2] as u64) | ((limbs[3] as u64) << 32),
+        (limbs[4] as u64) | ((limbs[5] as u64) << 32),
+        (limbs[6] as u64) | ((limbs[7] as u64) << 32),
+    ]
+}
+
+/// Convert to a [`U64x4`] array.
+// TODO(tarcieri): implement all algorithms in terms of `U256`?
+#[cfg(target_pointer_width = "64")]
+pub(crate) const fn u256_to_u64x4(u256: U256) -> U64x4 {
+    u256.to_words()
+}
+
+/// Convert from a [`U64x4`] array.
+#[cfg(target_pointer_width = "32")]
+pub(crate) const fn u64x4_to_u256(limbs: U64x4) -> U256 {
+    U256::from_words([
+        (limbs[0] & 0xFFFFFFFF) as u32,
+        (limbs[0] >> 32) as u32,
+        (limbs[1] & 0xFFFFFFFF) as u32,
+        (limbs[1] >> 32) as u32,
+        (limbs[2] & 0xFFFFFFFF) as u32,
+        (limbs[2] >> 32) as u32,
+        (limbs[3] & 0xFFFFFFFF) as u32,
+        (limbs[3] >> 32) as u32,
+    ])
+}
+
+/// Convert from a [`U64x4`] array.
+// TODO(tarcieri): implement all algorithms in terms of `U256`?
+#[cfg(target_pointer_width = "64")]
+pub(crate) const fn u64x4_to_u256(limbs: U64x4) -> U256 {
+    U256::from_words(limbs)
+}

--- a/p521/src/arithmetic/field.rs
+++ b/p521/src/arithmetic/field.rs
@@ -17,7 +17,8 @@
     clippy::unnecessary_cast,
     clippy::too_many_arguments,
     clippy::identity_op,
-    rustdoc::bare_urls
+    rustdoc::bare_urls,
+    unused_qualifications
 )]
 
 // TODO(tarcieri): 32-bit backend?


### PR DESCRIPTION
Beginings of a PR to distill the code diff in you (Automata network's) patch to accelerator p256 in RISC Zero zkVM.
It currently does not compile 😅 

My goal here is to have code diff that will be easy to use in our maintanance process. Our process is to maintain
the changes relative to upstream as a set of patches that can be applied on top of a tagged upstream release.
As examples, see the `k256/v0.13.2-risczero.0` [1] or `k256/v0.13.3-risczero.0` [2] tags.

[1] https://github.com/risc0/RustCrypto-elliptic-curves/commit/347e1e6a376c83e469d425be1da46363c40aaeaf
[2] https://github.com/risc0/RustCrypto-elliptic-curves/commit/d4f457a04410397cbb652a67c168b6cd6e9757c4
